### PR TITLE
Update v6.81 to v6.82

### DIFF
--- a/fm.reaper.Reaper.metainfo.xml
+++ b/fm.reaper.Reaper.metainfo.xml
@@ -23,7 +23,7 @@
       <image>https://www.reaper.fm/v6img/ss_persp_v63.jpg</image>
     </screenshot>
   </screenshots>
-    <releases>
+  <releases>
     <release version="v6.82" date="2023-08-23">
       <description>
         <p>The following components were updated:</p>
@@ -55,7 +55,6 @@
         </ul>
       </description>
     </release>
-  <releases>
     <release version="v6.81" date="2023-07-04">
       <description>
         <p>The following components were updated:</p>

--- a/fm.reaper.Reaper.metainfo.xml
+++ b/fm.reaper.Reaper.metainfo.xml
@@ -28,33 +28,6 @@
       <description>
         <p>The following components were updated:</p>
         <ul>
-          <li>Accessibility</li>
-          <li>Actions window</li>
-          <li>Import</li>
-          <li>MIDI</li>
-          <li>ARA</li>
-          <li>AU.</li>
-          <li>Command line</li>
-          <li>Custom menus/toolbars</li>
-          <li>FX.</li>
-          <li>Linux</li>
-          <li>macOS</li>
-          <li>Media items</li>
-          <li>Metadata</li>
-          <li>ReaSurroundPan</li>
-          <li>Save as</li>
-          <li>Silence removal</li>
-          <li>Track icons</li>
-          <li>Video</li>
-          <li>API</li>
-        </ul>
-      </description>
-    </release>
-  <releases>
-    <release version="v6.81" date="2023-07-04">
-      <description>
-        <p>The following components were updated:</p>
-        <ul>
           <li>Project bay</li>
           <li>ReaScript</li>
           <li>Actions</li>
@@ -78,6 +51,33 @@
           <li>Tabs</li>
           <li>Take</li>
           <li>Windows</li>
+          <li>API</li>
+        </ul>
+      </description>
+    </release>
+  <releases>
+    <release version="v6.81" date="2023-07-04">
+      <description>
+        <p>The following components were updated:</p>
+        <ul>
+          <li>Accessibility</li>
+          <li>Actions window</li>
+          <li>Import</li>
+          <li>MIDI</li>
+          <li>ARA</li>
+          <li>AU.</li>
+          <li>Command line</li>
+          <li>Custom menus/toolbars</li>
+          <li>FX.</li>
+          <li>Linux</li>
+          <li>macOS</li>
+          <li>Media items</li>
+          <li>Metadata</li>
+          <li>ReaSurroundPan</li>
+          <li>Save as</li>
+          <li>Silence removal</li>
+          <li>Track icons</li>
+          <li>Video</li>
           <li>API</li>
         </ul>
       </description>

--- a/fm.reaper.Reaper.metainfo.xml
+++ b/fm.reaper.Reaper.metainfo.xml
@@ -31,7 +31,7 @@
           <li>Project bay</li>
           <li>ReaScript</li>
           <li>Actions</li>
-          <li>FX</li>
+          <li>Effects</li>
           <li>JSFX</li>
           <li>Localization</li>
           <li>macOS</li>

--- a/fm.reaper.Reaper.metainfo.xml
+++ b/fm.reaper.Reaper.metainfo.xml
@@ -23,8 +23,8 @@
       <image>https://www.reaper.fm/v6img/ss_persp_v63.jpg</image>
     </screenshot>
   </screenshots>
-  <releases>
-    <release version="v6.81" date="2023-07-04">
+    <releases>
+    <release version="v6.82" date="2023-08-23">
       <description>
         <p>The following components were updated:</p>
         <ul>
@@ -46,6 +46,38 @@
           <li>Silence removal</li>
           <li>Track icons</li>
           <li>Video</li>
+          <li>API</li>
+        </ul>
+      </description>
+    </release>
+  <releases>
+    <release version="v6.81" date="2023-07-04">
+      <description>
+        <p>The following components were updated:</p>
+        <ul>
+          <li>Project bay</li>
+          <li>ReaScript</li>
+          <li>Actions</li>
+          <li>FX</li>
+          <li>JSFX</li>
+          <li>Localization</li>
+          <li>macOS</li>
+          <li>Metadata</li>
+          <li>Mouse</li>
+          <li>Project tabs</li>
+          <li>Accessibility</li>
+          <li>ARA</li>
+          <li>Batch converter</li>
+          <li>CLAP</li>
+          <li>LV2</li>
+          <li>MIDI editor</li>
+          <li>Mixer</li>
+          <li>Navigator</li>
+          <li>Preferences</li>
+          <li>Raw PCM media</li>
+          <li>Tabs</li>
+          <li>Take</li>
+          <li>Windows</li>
           <li>API</li>
         </ul>
       </description>

--- a/fm.reaper.Reaper.yml
+++ b/fm.reaper.Reaper.yml
@@ -64,15 +64,15 @@ modules:
       - type: extra-data
         filename: reaper.tar.xz
         url: https://www.reaper.fm/files/6.x/reaper682_linux_x86_64.tar.xz
-        sha256: 673b7f83deb2033b44d0d8d56b8b9a59705c912be71b13f42bcec79aaf36322d
-        size: 11680000
+        sha256: dafb643a874c8f42462d0427e1af971f1a1d1d0aa99d25b579aeefe9a0bdb07a
+        size: 11705948
         only-arches: [x86_64]
 
       - type: extra-data
         filename: reaper.tar.xz
         url: https://www.reaper.fm/files/6.x/reaper682_linux_aarch64.tar.xz
-        sha256: 3cd5149bbc4da4f47241a666f580d7cac275ca8fc8cf1533fa4a88ebf67a7e9a
-        size: 10339688
+        sha256: 14135f5d39f1aaadb60a716b136cef7fa903cbfa7ff925ceceacfb252dc8746f
+        size: 10352064
         only-arches: [aarch64]
 
       - type: script

--- a/fm.reaper.Reaper.yml
+++ b/fm.reaper.Reaper.yml
@@ -63,14 +63,14 @@ modules:
           - rm -rf /app/extra/export/share/reaper_linux_*
       - type: extra-data
         filename: reaper.tar.xz
-        url: https://www.reaper.fm/files/6.x/reaper681_linux_x86_64.tar.xz
+        url: https://www.reaper.fm/files/6.x/reaper682_linux_x86_64.tar.xz
         sha256: 673b7f83deb2033b44d0d8d56b8b9a59705c912be71b13f42bcec79aaf36322d
         size: 11680000
         only-arches: [x86_64]
 
       - type: extra-data
         filename: reaper.tar.xz
-        url: https://www.reaper.fm/files/6.x/reaper681_linux_aarch64.tar.xz
+        url: https://www.reaper.fm/files/6.x/reaper682_linux_aarch64.tar.xz
         sha256: 3cd5149bbc4da4f47241a666f580d7cac275ca8fc8cf1533fa4a88ebf67a7e9a
         size: 10339688
         only-arches: [aarch64]


### PR DESCRIPTION
Hi!

Reaper was updated recently, and as the update is minor, only the download URL need to be changed in the YAML.

Thanks!