### PR TITLE
Change html element to match for

### DIFF
--- a/fm.reaper.Reaper.yml
+++ b/fm.reaper.Reaper.yml
@@ -72,7 +72,7 @@ modules:
         x-checker-data:
           type: html
           url: https://www.reaper.fm/download.php
-          version-pattern: <div class="downloadinfo">REAPER v([\d\.-]*) -
+          version-pattern: "<div class='hdrbottom'>Version ([\\d\\.-]*):"
           url-template: https://www.reaper.fm/files/7.x/reaper${major}${minor}_linux_x86_64.tar.xz
 
       - type: extra-data
@@ -85,7 +85,7 @@ modules:
         x-checker-data:
           type: html
           url: https://www.reaper.fm/download.php
-          version-pattern: <div class="downloadinfo">REAPER v([\d\.-]*) -
+          version-pattern: "<div class='hdrbottom'>Version ([\\d\\.-]*):"
           url-template: https://www.reaper.fm/files/7.x/reaper${major}${minor}_linux_aarch64.tar.xz
 
       - type: script


### PR DESCRIPTION
The old syntax was probably correct, just used the wrong `"` - that should have been `'`. But actually downloading the `.php` file with curl showed a better place to match for.

Matching where we matched before, also had newlines in between, which might have caused issues.