### PR TITLE
Update LinuxAudio.Plugins and ffmpeg extensions

### DIFF
--- a/fm.reaper.Reaper.yml
+++ b/fm.reaper.Reaper.yml
@@ -18,15 +18,15 @@ finish-args:
 add-extensions:
   org.freedesktop.LinuxAudio.Plugins:
     directory: extensions/Plugins
-    version: "23.08"
+    version: "24.08"
     add-ld-path: lib
-    merge-dirs: lv2;vst;vst3
+    merge-dirs: ladspa;dssi;lv2;clap;vst;vst3
     subdirectories: true
     no-autodownload: true
 
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg
-    version: "23.08"
+    version: "24.08"
     add-ld-path: .
     autodelete: false
 


### PR DESCRIPTION
Update the plugins and ffmpeg to the 24.08 runtime version.

Not sure if we want to update the plugin reference though. If we do, we can no longer use plugins that do not have a 24.08 branch: https://github.com/flathub/org.freedesktop.LinuxAudio.BaseExtension/issues/14