### PR TITLE
Update to Reaper v7.40 and fix some metadata issues

### DIFF
--- a/fm.reaper.Reaper.metainfo.xml
+++ b/fm.reaper.Reaper.metainfo.xml
@@ -24,6 +24,53 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="v7.40" date="2025-06-10">
+      <description>
+        <p>REAPER 7.40: Render Reveal Party</p>
+        <p>The following components were updated:</p>
+        <ul>
+          <li>Actions</li>
+          <li>Audio Units</li>
+          <li>Big clock</li>
+          <li>Click source</li>
+          <li>Crossfade editor</li>
+          <li>Crossfades</li>
+          <li>Envelopes</li>
+          <li>Joysticks</li>
+          <li>Linux</li>
+          <li>Localization</li>
+          <li>LV2</li>
+          <li>macOS</li>
+          <li>Media explorer</li>
+          <li>Menu/toolbar customization window</li>
+          <li>Meters</li>
+          <li>MIDI</li>
+          <li>MIDI editor</li>
+          <li>Mouse modifiers</li>
+          <li>Paste</li>
+          <li>Peaks</li>
+          <li>Peaks building</li>
+          <li>Phase aligner</li>
+          <li>Project settings</li>
+          <li>Razor edits</li>
+          <li>ReaControlMIDI</li>
+          <li>ReaEQ</li>
+          <li>ReaNINJAM</li>
+          <li>ReaPlugs</li>
+          <li>ReaScript</li>
+          <li>ReaSurroundPan</li>
+          <li>ReaVerb</li>
+          <li>Render window</li>
+          <li>RS5k</li>
+          <li>Ruler</li>
+          <li>Samplerate conversion</li>
+          <li>Snapping</li>
+          <li>Theme</li>
+          <li>Wildcards</li>
+          <li>Windows</li>
+        </ul>
+      </description>
+    </release>
     <release version="v7.39" date="2025-05-12">
       <description>
         <p>REAPER 7.39: Render Reveal Party</p>
@@ -866,6 +913,8 @@
       </description>
     </release>
   </releases>
-  <developer_name>Cockos Incorporated</developer_name>
+  <developer id="com.cockos">
+    <name>Cockos Incorporated</name>
+  </developer>
   <update_contact>support@cockos.com</update_contact>
 </component>

--- a/fm.reaper.Reaper.yml
+++ b/fm.reaper.Reaper.yml
@@ -64,9 +64,9 @@ modules:
       - type: extra-data
         filename: reaper.tar.xz
 
-        url: https://www.reaper.fm/files/7.x/reaper739_linux_x86_64.tar.xz
-        sha256: 01e7bc8334b483007d214d47e46a5a2fba09e222b240b76914cbd08df8016040
-        size: 12805472
+        url: https://www.reaper.fm/files/7.x/reaper740_linux_x86_64.tar.xz
+        sha256: 46a8650fa0ca8b5f8cd8586410ce524b18a68b0743ede69d90211a39d0b10701
+        size: 12859744
         only-arches: [x86_64]
 
         x-checker-data:
@@ -77,9 +77,9 @@ modules:
 
       - type: extra-data
         filename: reaper.tar.xz
-        url: https://www.reaper.fm/files/7.x/reaper739_linux_aarch64.tar.xz
-        sha256: 07e556b46439a41138df8a4771cb9b1d93e436a4f99e436cbaf87128b6b52267
-        size: 11505436
+        url: https://www.reaper.fm/files/7.x/reaper740_linux_aarch64.tar.xz
+        sha256: 22ae6842e29779b5bf8d4644804c74f46e85942bb19a0ad1254301c070156b12
+        size: 11549500
         only-arches: [aarch64]
 
         x-checker-data:


### PR DESCRIPTION
In addition to fixing the metadata issue blocking the update to v7.40, I also added the changelog to the release description, and removed the deprecated `<developer_name>` tag from AppStream metadata.

The problem that was blocking the update was the Flathub bot putting 7.40 in the release metadata, instead of v7.40. When the linter checked it, it thought that 7.40 was older than v7.39, causing it to fail. Is there any way this could be fixed so this doesn't happen again?