### PR TITLE
Add libxml2 2.13.9 module for REAPER compatibility

### DIFF
--- a/fm.reaper.Reaper.yml
+++ b/fm.reaper.Reaper.yml
@@ -25,6 +25,19 @@ add-extensions:
     no-autodownload: true
 
 modules:
+  - name: libxml2
+    config-opts:
+      - --without-python
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.9.tar.xz
+        sha256: a2c9ae7b770da34860050c309f903221c67830c86e4a7e760692b803df95143a
+        x-checker-data:
+          type: anitya
+          project-id: 5552
+          stable-only: true
+          url-template: https://download.gnome.org/sources/libxml2/2.13/libxml2-$version.tar.xz
+
   - name: reaper
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
REAPER expects libxml2.so.2 but freedesktop SDK 25.08 ships libxml2.so.16 (SONAME bump in 2.14+). Bundling libxml2 2.13.9 resolves this by providing the older SONAME.

Fixes #106